### PR TITLE
Fixes in coordinates and nodes offset

### DIFF
--- a/src/components/flowchart/Flowchart.vue
+++ b/src/components/flowchart/Flowchart.vue
@@ -194,7 +194,7 @@ export default {
         this.selectionInfo = null;
       }
       if (this.moveInfo) {
-        this.moveCoordinates.diffX += event.pageX - this.moveCoordinates.startX;
+        this.moveCoordinates.diffX -= event.pageX - this.moveCoordinates.startX;
         this.moveCoordinates.diffY += event.pageY - this.moveCoordinates.startY;
         this.$emit(
             "movediff",
@@ -818,6 +818,8 @@ export default {
       that.internalConnections.splice(0, that.internalConnections.length);
       that.nodes.forEach((node) => {
         let newNode = Object.assign({}, node);
+        newNode.x = newNode.x + this.moveCoordinates.diffX;
+        newNode.y = newNode.y + this.moveCoordinates.diffY;
         newNode.width = newNode.width || 120;
         newNode.height = newNode.height || 60;
         that.internalNodes.push(newNode);


### PR DESCRIPTION
- Fixed moveCoordinates x-axis value, now it follows maths rules.
- _Init_ method updates nodes coordinates if elements were moved before init function execution. It have to happen because in other case newly rendered nodes are in invalid position - without offset added by execution of _handleChartMouseDown_ callback with pushed ctrl key.